### PR TITLE
Fix multiple anchors bug

### DIFF
--- a/dna/anchors/anchors.js
+++ b/dna/anchors/anchors.js
@@ -12,9 +12,9 @@ function anchor(anchor){
     debug('anchorTypeGet ' + JSON.stringify(anchorTypeGet));
     debug('<mermaid>' + App.Agent.String + '-->>DHT:Check to see if ' + anchor.anchorType + ' has been setup</mermaid>');
     if(anchorTypeGet === null){
-      var rootAnchorTypeHash = get(makeHash('anchor', rootAnchortype));
+      var rootAnchorTypeHash = makeHash('anchor', rootAnchortype);
       debug('<mermaid>' + App.Agent.String + '-->>DHT:Check to see if the Root of all anchors has been setup</mermaid>');
-      if (rootAnchorTypeHash === null){
+      if (get(rootAnchorTypeHash) === null){
         rootAnchorTypeHash = commit('anchor', rootAnchortype);
         debug('<mermaid>' + App.Agent.String + '->>' + App.Agent.String + ':commit Root of all anchors to local chain</mermaid>');
         debug('<mermaid>' + App.Agent.String + '->>DHT:Publish Root of all anchors</mermaid>');
@@ -25,6 +25,7 @@ function anchor(anchor){
       debug('<mermaid>' + App.Agent.String + '->>' + App.Agent.String + ':commit ' + anchor.anchorType + ' to local chain</mermaid>');
       debug('<mermaid>' + App.Agent.String + '->>DHT:Publish ' + anchor.anchorType + '</mermaid>');
       // debug('Anchor Type Created: ' + anchorTypeHash)
+
       commit('anchor_link', { Links:[{Base: rootAnchorTypeHash, Link: anchorTypeHash, Tag: anchorType.anchorType}]});
       debug('<mermaid>' + App.Agent.String + '->>DHT:Link ' + anchor.anchorType + ' to Root of all anchors</mermaid>');
 

--- a/test/anchors.json
+++ b/test/anchors.json
@@ -11,6 +11,16 @@
         "Regexp": ""
     },
     {
+        "Convey":"Ask for an anchor that is not there again...",
+        "Zome": "anchors",
+        "FnName": "anchor",
+        "Input": {"anchorType": "test2", "anchorText": "Will"},
+        "Output": "%h1%",
+        "Exposure":"public",
+        "Err": "",
+        "Regexp": ""
+    },
+    {
         "Convey":"Check to see if an anchor exists",
         "Zome": "anchors",
         "FnName": "exists",


### PR DESCRIPTION
I found a bug in the anchors zome that prevents the creation of a new anchor type once the root anchor has been committed. 

This can be seen in the newly added test case in anchors.json. The first new anchor type passes but fails creating a second type. This was not tested for previously.

This bug was caused by an error in anchors.js where the variable rootAnchorTypeHash was set to the response of a get() rather than the hash itself. This was then used as the base of a link, causing an error. This only occurrerd in the conditional branch where the root anchor had already been created. 

Bug is fixed and an additional test case included.